### PR TITLE
Make context timeout configurable

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -25,7 +25,7 @@ var (
 
 var (
 	// DefaultContextTimeout is the default timeout in which broker requests
-	// (and therefore Provider implementations) should return within
+	// (and therefore Provider implementations) should return
 	DefaultContextTimeout = time.Second * 60
 )
 
@@ -99,7 +99,7 @@ func (b *Broker) Provision(
 		return domain.ProvisionedServiceSpec{}, err
 	}
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lock, err := b.ObtainServiceLock(providerCtx, instanceID, locketMaxTTL)
@@ -157,7 +157,7 @@ func (b *Broker) Deprovision(
 		return domain.DeprovisionServiceSpec{}, brokerapi.ErrAsyncRequired
 	}
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	service, err := findServiceByID(b.config.Catalog, details.ServiceID)
@@ -221,7 +221,7 @@ func (b *Broker) Bind(
 		"details":     details,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lock, err := b.ObtainServiceLock(providerCtx, instanceID, locketMaxTTL)
@@ -274,7 +274,7 @@ func (b *Broker) Unbind(
 		"details":     details,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lock, err := b.ObtainServiceLock(providerCtx, instanceID, locketMaxTTL)
@@ -324,7 +324,7 @@ func (b *Broker) GetBinding(
 		"binding-id":  bindingID,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	data := provider.GetBindData{
@@ -382,7 +382,7 @@ func (b *Broker) Update(
 		return domain.UpdateServiceSpec{}, err
 	}
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lock, err := b.ObtainServiceLock(providerCtx, instanceID, locketMaxTTL)
@@ -429,7 +429,7 @@ func (b *Broker) LastOperation(
 		"poll-details": pollDetails,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lastOperationData := provider.LastOperationData{
@@ -469,7 +469,7 @@ func (b *Broker) LastBindingOperation(
 		"poll-details": pollDetails,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lastOperationData := provider.LastBindingOperationData{

--- a/broker/config.go
+++ b/broker/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"reflect"
 	"strings"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/pivotal-cf/brokerapi/domain"
@@ -89,12 +90,13 @@ func (c Config) Validate() error {
 }
 
 type API struct {
-	BasicAuthUsername string `json:"basic_auth_username"`
-	BasicAuthPassword string `json:"basic_auth_password"`
-	Port              string `json:"port"`
-	LogLevel          string `json:"log_level"`
-	LagerLogLevel     lager.LogLevel
-	Locket            *LocketConfig `json:"locket"`
+	BasicAuthUsername     string `json:"basic_auth_username"`
+	BasicAuthPassword     string `json:"basic_auth_password"`
+	Port                  string `json:"port"`
+	LogLevel              string `json:"log_level"`
+	LagerLogLevel         lager.LogLevel
+	Locket                *LocketConfig `json:"locket"`
+	ContextTimeoutSeconds int           `json:"context_timeout_seconds"`
 }
 
 func (api API) ConvertLogLevel() (lager.LogLevel, error) {
@@ -109,6 +111,13 @@ func (api API) ConvertLogLevel() (lager.LogLevel, error) {
 		return lager.DEBUG, fmt.Errorf("Config error: log level %s does not map to a Lager log level", api.LogLevel)
 	}
 	return logLevel, nil
+}
+
+func (api API) ContextTimeout() time.Duration {
+	if api.ContextTimeoutSeconds == 0 {
+		return DefaultContextTimeout
+	}
+	return time.Duration(api.ContextTimeoutSeconds) * time.Second
 }
 
 type Catalog struct {

--- a/broker/config_test.go
+++ b/broker/config_test.go
@@ -154,6 +154,21 @@ var _ = Describe("Config", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.API.LogLevel).To(Equal(DefaultLogLevel))
 		})
+
+		It("sets a default context_timeout_seconds", func() {
+			configSource = `
+				{
+					"basic_auth_username":"username",
+					"basic_auth_password":"1234",
+					"port": "8080",
+					"catalog": {"services": [{"name": "service1", "plans": [{"name": "plan1"}]}]},
+					"locket": {"address": "my.locker.server"}
+				}
+			`
+			config, err := NewConfig(strings.NewReader(configSource))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.API.ContextTimeout()).To(Equal(DefaultContextTimeout))
+		})
 	})
 
 	Describe("Catalog", func() {


### PR DESCRIPTION
This adds a ContextTimeout field to Broker to allow callers to
customize the context timeout.  The motivation is
https://github.com/alphagov/paas-sqs-broker/pull/18 – we need a longer
timeout when trying to create a binding using CloudFormation.

It's possible to override it by using an init() func to change the
value of broker.DefaultContextTimeout but this is hackery.  Much
better to make it directly configurable.